### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ This server implements the [Model Context Protocol (MCP)](https://modelcontextpr
 - **Standardized error handling** with helpful suggestions
 - **Full TypeScript support** with strict typing
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/sidneybissoli-ibge-br-mcp).
+
 ## Available Tools
 
 ### Localities & Geography


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/sidneybissoli-ibge-br-mcp).