### PR TITLE
fix(contrato): disjuntor e prazos coerentes; re-roda em runner novo

### DIFF
--- a/.github/workflows/integration-retry.yml
+++ b/.github/workflows/integration-retry.yml
@@ -1,0 +1,65 @@
+name: Integration retry
+
+# Re-roda num runner NOVO um job de integracao que falhou.
+#
+# Por que existe, MEDIDO em 12/09/2026: a fonte descarta pacotes de alguns
+# enderecos de origem, e o job que cai num deles esta perdido. Vinte runners
+# do GitHub dispararam no mesmo instante contra o Senado: 18 conectaram e 2
+# nao receberam NENHUMA resposta de TCP, em nenhum endereco do alvo, com
+# User-Agent nominal e com um curl generico igualmente, enquanto buscavam um
+# site de controle em menos de 60 ms. Vizinhos nas mesmas faixas da Azure
+# passaram: e lista por endereco, nao faixa de nuvem recusada.
+#
+# Neste repo o fenomeno apareceu no mesmo dia: a rodada das 09:52 UTC travou
+# e foi cortada pelo teto de 15 min; a re-rodada 17 min depois, mesmo codigo
+# e mesmo alvo, passou em 70 s. So mudou o runner.
+#
+# A cura e endereco novo, e nada mais. `gh run rerun --failed` re-roda so o
+# que falhou, num runner novo. A espera de 60 s nao serve para desbloquear
+# nada - so evita girar em falso diante de falha sistemica.
+
+on:
+  workflow_run:
+    workflows: ["Integration tests (live IBGE APIs)"]
+    types: [completed]
+
+permissions:
+  actions: write # gh run rerun
+
+jobs:
+  rerun:
+    # Deliberadamente NAO e `!= 'success'`: rodada cancelada a mao tambem
+    # reporta `cancelled`, e re-roda-la atropelaria a decisao de quem cancelou.
+    if: >-
+      (github.event.workflow_run.conclusion == 'failure' ||
+       github.event.workflow_run.conclusion == 'timed_out') &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Espera curta e re-roda o que falhou num runner novo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -euo pipefail
+          echo "run $RUN_ID nao passou na tentativa $ATTEMPT; esperando 60s"
+          sleep 60
+          # Cinto para a guarda do job: expressao do GitHub converte campo
+          # ausente em 0, e `0 < 3` seria verdadeiro para sempre - falha real
+          # e reproduzivel viraria retry infinito. Perguntar a API em que
+          # tentativa a rodada esta, e recusar a partir do numero vivo.
+          live=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID"             --jq '.run_attempt')
+          case "$live" in
+            ''|*[!0-9]*)
+              echo "nao consegui ler run_attempt (veio '$live'); recusando" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$live" -ge 3 ]; then
+            echo "run $RUN_ID ja esta na tentativa $live; desistindo"
+            exit 0
+          fi
+          gh run rerun "$RUN_ID" --failed -R "${{ github.repository }}"
+          echo "re-rodada pedida para os jobs vermelhos de $RUN_ID"

--- a/tests/catalog-contract.integration.test.ts
+++ b/tests/catalog-contract.integration.test.ts
@@ -107,20 +107,70 @@ function normalize(s: string): string {
     .toLowerCase();
 }
 
+/**
+ * Orçamento por requisição. Era 45 s, dentro de um prazo de teste de 180 s —
+ * três tentativas somavam 147 s por código, e com 33 códigos um runner que
+ * não alcança o IBGE levava ~81 min para dizer isso. A API responde em ~250 ms
+ * quando responde; 20 s é oitenta vezes isso, folga de sobra para lentidão
+ * real sem transformar silêncio em hora de runner.
+ */
+const ORCAMENTO_REQUISICAO_MS = 20_000;
+const ESPERA_BASE_MS = 1000;
+
+/** O IBGE nunca respondeu: DNS, TCP, TLS, abort. Diferente de um status HTTP. */
+class FalhaDeTransporte extends Error {
+  constructor(causa: unknown) {
+    super(String(causa));
+    this.name = "FalhaDeTransporte";
+  }
+}
+
+/**
+ * Disjuntor. Medido em 12/09/2026: a fonte descarta pacotes de alguns
+ * endereços de origem, e o runner que cai num deles não fala com ela o job
+ * inteiro. Aconteceu aqui: a rodada das 09:52 UTC travou e foi cortada pelo
+ * teto de 15 min; a re-rodada 17 min depois, mesmo código e mesmo alvo, passou
+ * em 70 s — só mudou o runner. Sem disjuntor, cada um dos 33 códigos paga o
+ * orçamento inteiro para descobrir a mesma coisa.
+ *
+ * Só arma enquanto NADA foi lido: depois que o IBGE respondeu uma vez ele está
+ * alcançável, e uma falha posterior é daquele código, não da conexão.
+ */
+const LIMITE_TRANSPORTE = 3;
+let leiturasOk = 0;
+let sequenciaTransporte = 0;
+
+function disjuntorAberto(): boolean {
+  return leiturasOk === 0 && sequenciaTransporte >= LIMITE_TRANSPORTE;
+}
+
 async function tableName(code: string): Promise<string> {
   const url = `https://servicodados.ibge.gov.br/api/v3/agregados/${code}/metadados`;
   let lastErr: unknown;
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
-      const res = await fetch(url, { signal: AbortSignal.timeout(45_000) });
+      let res: Response;
+      try {
+        res = await fetch(url, { signal: AbortSignal.timeout(ORCAMENTO_REQUISICAO_MS) });
+      } catch (err) {
+        throw new FalhaDeTransporte(err);
+      }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const meta = (await res.json()) as { nome?: string };
       if (!meta.nome) throw new Error("metadados sem campo nome");
+      leiturasOk++;
+      sequenciaTransporte = 0;
       return meta.nome;
     } catch (err) {
       lastErr = err;
-      await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+      await new Promise((r) => setTimeout(r, ESPERA_BASE_MS * (attempt + 1)));
     }
+  }
+  if (lastErr instanceof FalhaDeTransporte) {
+    sequenciaTransporte++;
+  } else {
+    // Uma resposta CHEGOU e foi recusada: a conexão está de pé.
+    sequenciaTransporte = 0;
   }
   throw new Error(`tabela ${code}: falha ao consultar metadados — ${String(lastErr)}`);
 }
@@ -141,6 +191,14 @@ describe.runIf(LIVE)("contrato do catálogo SIDRA (API real)", () => {
     const users = declared.filter((d) => d.code === code);
     const where = users.map((u) => `${u.origin}:${u.label}`).join("; ");
     it(`tabela ${code} é o que o catálogo promete [${where}]`, async () => {
+      if (disjuntorAberto()) {
+        throw new Error(
+          `IBGE inalcançável deste runner: ${sequenciaTransporte} códigos seguidos ` +
+            `sem nenhuma resposta e nenhuma leitura bem-sucedida. O contrato do ` +
+            `catálogo NÃO foi medido — isto não diz nada sobre o código ${code}. ` +
+            `Re-rodar cai num runner novo, com outro endereço de origem.`
+        );
+      }
       const nome = await tableName(code);
       const expected = EXPECTED[code];
       if (!expected) return; // já reportado no teste de completude
@@ -148,6 +206,9 @@ describe.runIf(LIVE)("contrato do catálogo SIDRA (API real)", () => {
         expected.test(normalize(nome)),
         `tabela ${code} na API é "${nome}" — não bate com a expectativa ${expected} declarada para: ${where}`
       ).toBe(true);
-    }, 180_000);
+      // Prazo por teste: 3 tentativas de 20 s mais 1 s + 2 s de espera = 63 s
+      // no pior caso. Era 180 s, herdado de um orçamento de 45 s por
+      // requisição que já não existe.
+    }, 90_000);
   }
 });


### PR DESCRIPTION
## O teto novo pegou uma instância de verdade na primeira rodada

O `timeout-minutes: 15` que entrou hoje cortou a rodada das 09:52 UTC aos **921 s**. A re-rodada 17 minutos depois, **mesmo código e mesmo alvo**, passou em **70 s**. Só mudou o runner.

## A causa, medida

A fonte descarta pacotes de alguns endereços de origem. Vinte runners do GitHub dispararam no mesmo instante contra o Senado, no repo irmão:

| resultado | runners |
|---|---|
| conectaram | 18 |
| nenhuma resposta de TCP, em todos os endereços do alvo | 2 |
| alcançaram o site de controle | 20 |

Sem resposta com o User-Agent nominal e com um `curl/8.5.0` genérico igualmente. Vizinhos dentro das mesmas faixas da Azure conectaram. É **lista por endereço**, não faixa de nuvem recusada.

## O que este teste fazia nesse regime

Orçamento de **45 s por requisição**, 3 tentativas, esperas de 2/4/6 s: **147 s por código**. Com 33 códigos, um runner bloqueado levaria **cerca de 81 minutos** para concluir que não falou com o IBGE. O prazo de 180 s por teste escondia a incoerência, já que 45 s nunca caberia nos 10 s do `testTimeout` global.

## As três mudanças

1. **Prazos coerentes.** Orçamento por requisição de 45 s para 20 s, que é oitenta vezes os ~250 ms em que a API responde quando responde. Esperas de 1/2 s. Prazo por teste de 180 s para 90 s, folga sobre os 63 s do pior caso real.
2. **Falha de transporte ganhou tipo próprio.** "O IBGE não respondeu" deixou de se confundir com "respondeu e foi recusado".
3. **Disjuntor.** Três códigos seguidos sem nenhuma resposta e nenhuma leitura boa, e os demais falham na hora, dizendo que o contrato **não foi medido** e que re-rodar cai em outro endereço. Só arma enquanto nada foi lido: depois que o IBGE respondeu uma vez, falha é daquele código.

Mais o workflow `Integration retry`, que re-roda só os jobs vermelhos num runner novo, até 3 tentativas, lendo a tentativa viva da API em vez de confiar no payload do evento.

## Provas

- 741 testes unitários verdes.
- A integração ao vivo passa em **2,16 s**, 32 casos.
- Com toda requisição falhando em transporte, só **3 códigos** pagam rede e o arquivo fecha em **20 s**, contra os ~81 min do desenho anterior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArspxE1wayiqsNgDWq28bW
