### PR TITLE
fix(integração): um blip de conexão não pode derrubar o contrato semanal

### DIFF
--- a/tests/catalog-contract.integration.test.ts
+++ b/tests/catalog-contract.integration.test.ts
@@ -28,6 +28,7 @@ import { INDICADORES_SAUDE } from "../src/tools/datasaude.js";
 import { INDICADORES_CONHECIDOS } from "../src/tools/indicadores.js";
 import { TEMPLATES_COMPARACAO } from "../src/tools/comparar.js";
 import { TABELAS_COMUNS } from "../src/tools/sidra.js";
+import { fetchIntegracao, FalhaDeTransporte } from "./integration-fetch.js";
 
 const LIVE = process.env.INTEGRATION_TESTS === "1" || process.env.INTEGRATION_TESTS === "true";
 
@@ -108,24 +109,6 @@ function normalize(s: string): string {
 }
 
 /**
- * Orçamento por requisição. Era 45 s, dentro de um prazo de teste de 180 s —
- * três tentativas somavam 147 s por código, e com 33 códigos um runner que
- * não alcança o IBGE levava ~81 min para dizer isso. A API responde em ~250 ms
- * quando responde; 20 s é oitenta vezes isso, folga de sobra para lentidão
- * real sem transformar silêncio em hora de runner.
- */
-const ORCAMENTO_REQUISICAO_MS = 20_000;
-const ESPERA_BASE_MS = 1000;
-
-/** O IBGE nunca respondeu: DNS, TCP, TLS, abort. Diferente de um status HTTP. */
-class FalhaDeTransporte extends Error {
-  constructor(causa: unknown) {
-    super(String(causa));
-    this.name = "FalhaDeTransporte";
-  }
-}
-
-/**
  * Disjuntor. Medido em 12/09/2026: a fonte descarta pacotes de alguns
  * endereços de origem, e o runner que cai num deles não fala com ela o job
  * inteiro. Aconteceu aqui: a rodada das 09:52 UTC travou e foi cortada pelo
@@ -146,33 +129,25 @@ function disjuntorAberto(): boolean {
 
 async function tableName(code: string): Promise<string> {
   const url = `https://servicodados.ibge.gov.br/api/v3/agregados/${code}/metadados`;
-  let lastErr: unknown;
-  for (let attempt = 0; attempt < 3; attempt++) {
-    try {
-      let res: Response;
-      try {
-        res = await fetch(url, { signal: AbortSignal.timeout(ORCAMENTO_REQUISICAO_MS) });
-      } catch (err) {
-        throw new FalhaDeTransporte(err);
-      }
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const meta = (await res.json()) as { nome?: string };
-      if (!meta.nome) throw new Error("metadados sem campo nome");
-      leiturasOk++;
-      sequenciaTransporte = 0;
-      return meta.nome;
-    } catch (err) {
-      lastErr = err;
-      await new Promise((r) => setTimeout(r, ESPERA_BASE_MS * (attempt + 1)));
-    }
-  }
-  if (lastErr instanceof FalhaDeTransporte) {
-    sequenciaTransporte++;
-  } else {
-    // Uma resposta CHEGOU e foi recusada: a conexão está de pé.
+  try {
+    // `fetchIntegracao` já repete falha de transporte; o que sobra aqui é
+    // decidir o que a resposta significa e alimentar o disjuntor.
+    const res = await fetchIntegracao(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const meta = (await res.json()) as { nome?: string };
+    if (!meta.nome) throw new Error("metadados sem campo nome");
+    leiturasOk++;
     sequenciaTransporte = 0;
+    return meta.nome;
+  } catch (err) {
+    if (err instanceof FalhaDeTransporte) {
+      sequenciaTransporte++;
+    } else {
+      // Uma resposta CHEGOU e foi recusada: a conexão está de pé.
+      sequenciaTransporte = 0;
+    }
+    throw new Error(`tabela ${code}: falha ao consultar metadados — ${String(err)}`);
   }
-  throw new Error(`tabela ${code}: falha ao consultar metadados — ${String(lastErr)}`);
 }
 
 describe.runIf(LIVE)("contrato do catálogo SIDRA (API real)", () => {

--- a/tests/integration-fetch.ts
+++ b/tests/integration-fetch.ts
@@ -1,0 +1,64 @@
+/**
+ * `fetch` com repetição para os testes de integração (rede real).
+ *
+ * Por que existe: em 12/09/2026 a rodada semanal ficou vermelha porque UMA
+ * conexão de UMA requisição não abriu — `UND_ERR_CONNECT_TIMEOUT` contra
+ * `servicodados.ibge.gov.br:443` — no mesmo runner que, segundos antes, tinha
+ * feito 32 leituras boas contra o mesmo host. Um blip isolado não diz nada
+ * sobre o contrato, mas derrubava o job inteiro e chegava ao painel do
+ * portfólio como "a fonte mudou".
+ *
+ * Regra: só repete falha de TRANSPORTE, quando o IBGE não respondeu nada.
+ * Resposta que chega é devolvida como está, inclusive 4xx e 5xx — vários
+ * testes daqui ASSERTAM um 400, e repetir isso esconderia o que eles medem.
+ *
+ * O outro regime, diferente deste, é o runner que não fala com a fonte o job
+ * inteiro: a fonte mantém lista de bloqueio por endereço de origem (medido em
+ * 12/09/2026 — de 20 runners simultâneos, 2 não receberam nenhuma resposta de
+ * TCP em nenhum endereço do alvo, enquanto 18 conectavam). Repetição não cura
+ * isso; quem cura é runner novo, e disso cuida o workflow `Integration retry`.
+ */
+
+/** O IBGE não respondeu: DNS, TCP, TLS, abort. Diferente de um status HTTP. */
+export class FalhaDeTransporte extends Error {
+  constructor(public readonly causa: unknown) {
+    super(String(causa));
+    this.name = "FalhaDeTransporte";
+  }
+}
+
+/**
+ * Orçamento por requisição. A API responde em ~250 ms quando responde; 20 s é
+ * oitenta vezes isso, folga de sobra para lentidão real sem transformar
+ * silêncio em hora de runner.
+ */
+export const ORCAMENTO_REQUISICAO_MS = 20_000;
+
+const TENTATIVAS = 3;
+const ESPERA_BASE_MS = 1000;
+
+function dorme(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Busca `url` repetindo só falhas de transporte. Devolve a `Response` assim
+ * que uma chegar, seja qual for o status. Esgotadas as tentativas, lança
+ * `FalhaDeTransporte`, para quem chama poder distinguir "não respondeu" de
+ * "respondeu e foi recusado".
+ */
+export async function fetchIntegracao(url: string, init: RequestInit = {}): Promise<Response> {
+  let ultima: unknown;
+  for (let tentativa = 0; tentativa < TENTATIVAS; tentativa++) {
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: init.signal ?? AbortSignal.timeout(ORCAMENTO_REQUISICAO_MS),
+      });
+    } catch (err) {
+      ultima = err;
+      if (tentativa < TENTATIVAS - 1) await dorme(ESPERA_BASE_MS * (tentativa + 1));
+    }
+  }
+  throw new FalhaDeTransporte(ultima);
+}

--- a/tests/malhas-contract.integration.test.ts
+++ b/tests/malhas-contract.integration.test.ts
@@ -32,6 +32,7 @@ import {
   type Nivel,
 } from "../src/tools/malhas.js";
 import { IBGE_API } from "../src/types.js";
+import { fetchIntegracao } from "./integration-fetch.js";
 
 const LIVE = process.env.INTEGRATION_TESTS === "1" || process.env.INTEGRATION_TESTS === "true";
 
@@ -59,7 +60,7 @@ const GEOJSON = encodeURIComponent("application/vnd.geo+json");
  */
 async function aceitosSegundoApi(nivel: Nivel): Promise<string[]> {
   const url = `${IBGE_API.MALHAS}/${nivel}/${EXEMPLO[nivel]}?formato=${GEOJSON}&intrarregiao=__invalido__`;
-  const resposta = await fetch(url);
+  const resposta = await fetchIntegracao(url);
   expect(resposta.status, `${nivel}: esperava 400 para intrarregiao inválida`).toBe(400);
   const { message } = (await resposta.json()) as { message?: string };
   expect(message, `${nivel}: a API não explicou o que aceita`).toBeTruthy();
@@ -87,7 +88,7 @@ describe.skipIf(!LIVE)("contrato de malhas contra a API v3 real", () => {
   for (const nivel of NIVEIS) {
     it(`${nivel}: o endpoint da ferramenta responde 200`, async () => {
       const url = `${IBGE_API.MALHAS}/${nivel}/${EXEMPLO[nivel]}?formato=${GEOJSON}&qualidade=minima`;
-      const resposta = await fetch(url);
+      const resposta = await fetchIntegracao(url);
       expect(resposta.status, `${nivel} em ${url}`).toBe(200);
     }, 30000);
   }
@@ -95,7 +96,7 @@ describe.skipIf(!LIVE)("contrato de malhas contra a API v3 real", () => {
   for (const qualidade of QUALIDADE_V3) {
     it(`a API aceita qualidade="${qualidade}"`, async () => {
       const url = `${IBGE_API.MALHAS}/paises/BR?formato=${GEOJSON}&qualidade=${qualidade}`;
-      expect((await fetch(url)).status).toBe(200);
+      expect((await fetchIntegracao(url)).status).toBe(200);
     }, 30000);
   }
 

--- a/tests/malhas-tema-contract.integration.test.ts
+++ b/tests/malhas-tema-contract.integration.test.ts
@@ -27,6 +27,7 @@
 import { describe, expect, it } from "vitest";
 import { ibgeMalhasTema, RECORTES, TEMAS } from "../src/tools/malhas-tema.js";
 import { IBGE_API } from "../src/types.js";
+import { fetchIntegracao } from "./integration-fetch.js";
 
 const LIVE = process.env.INTEGRATION_TESTS === "1" || process.env.INTEGRATION_TESTS === "true";
 
@@ -46,7 +47,7 @@ async function consulta(camada: string, campos: readonly string[], filtro?: stri
   url.searchParams.set("count", String(count));
   if (filtro) url.searchParams.set("CQL_FILTER", filtro);
 
-  const resposta = await fetch(url);
+  const resposta = await fetchIntegracao(url);
   expect(resposta.status, `${camada} em ${url}`).toBe(200);
   const corpo = (await resposta.json()) as Resposta;
   return corpo;
@@ -113,7 +114,7 @@ describe.skipIf(!LIVE)("contrato dos recortes temáticos no WFS do IBGE", () => 
     // E a URL que a ferramenta entrega para baixar a geometria precisa VALER —
     // é a única coisa que ela promete e não verifica sozinha. HEAD basta: o
     // corpo passa de 9 MB.
-    const resposta = await fetch(s.url_geometria, { method: "HEAD" });
+    const resposta = await fetchIntegracao(s.url_geometria, { method: "HEAD" });
     expect(resposta.status, s.url_geometria).toBe(200);
   }, 120000);
 });

--- a/tests/sidra-vazio.integration.test.ts
+++ b/tests/sidra-vazio.integration.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, it } from "vitest";
 import { ibgeSidra, sidraSchema } from "../src/tools/sidra.js";
 import { IBGE_API } from "../src/types.js";
+import { fetchIntegracao } from "./integration-fetch.js";
 
 const LIVE = process.env.INTEGRATION_TESTS === "1" || process.env.INTEGRATION_TESTS === "true";
 
@@ -27,7 +28,7 @@ const LIVE = process.env.INTEGRATION_TESTS === "1" || process.env.INTEGRATION_TE
 const TABELA = "6579";
 
 async function periodosDaFonte(tabela: string): Promise<number[]> {
-  const resposta = await fetch(`${IBGE_API.AGREGADOS}/${tabela}/periodos`);
+  const resposta = await fetchIntegracao(`${IBGE_API.AGREGADOS}/${tabela}/periodos`);
   expect(resposta.status).toBe(200);
   const periodos = (await resposta.json()) as Array<{ id?: string }>;
   return periodos.map((p) => Number(p?.id)).filter((n) => Number.isFinite(n));


### PR DESCRIPTION
## O que aconteceu

A rodada de prova de hoje ficou vermelha porque **uma** conexão de **uma** requisição não abriu:

```
TypeError: fetch failed
Caused by: ConnectTimeoutError (attempted address: servicodados.ibge.gov.br:443, timeout: 10000ms)
Serialized Error: { code: 'UND_ERR_CONNECT_TIMEOUT' }
```

No **mesmo runner** que, segundos antes, tinha feito 32 leituras boas contra o mesmo host. Não era bloqueio de endereço. Era blip isolado. Mesmo assim derrubou o job inteiro, e chegaria ao painel do portfólio como "a fonte mudou".

São dois regimes diferentes, e valia separar:

| regime | sintoma | cura |
|---|---|---|
| endereço de origem bloqueado | nada responde o job inteiro | runner novo (workflow `Integration retry`) |
| blip de conexão | uma requisição em dezenas | repetir a requisição |

O primeiro já estava coberto. O segundo não.

## O conserto

Havia **sete `fetch` crus** espalhados por três arquivos de integração, nenhum com repetição. Todos passam agora por `fetchIntegracao`, que repete **só falha de transporte**, com orçamento de 20 s e esperas de 1 s e 2 s.

Resposta que chega volta como está, **inclusive 4xx e 5xx**. Isso é deliberado: vários testes daqui asseratam um 400 de propósito, para ler o vocabulário que a própria API enumera na mensagem de erro. Repetir ou mascarar esse 400 esconderia exatamente o que eles medem.

O `catalog-contract` deixou de duplicar a lógica e passou a usar o mesmo helper, mantendo local só o disjuntor, que resolve o outro regime.

## Provas

- 741 testes unitários verdes, lint limpo.
- Os quatro arquivos de integração ao vivo passam em **9,0 s**, 75 casos.
- Com toda requisição falhando em transporte, os mesmos quatro fecham em **92 s** em vez de dezenas de minutos, e falham alto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArspxE1wayiqsNgDWq28bW
